### PR TITLE
fix: Fix release workflow not being triggered properly [skip ci]

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
 
-set -e
+echo "Pulling latest git commit..."
+git pull origin main
 
-DOCKER_COMPOSE_FILE="/home/faz/Workspace/Development/faz-bot/docker/docker-compose.yml"
-DOCKER_COMPOSE_CMD="docker-compose -f $DOCKER_COMPOSE_FILE"
+scrDir=$(dirname "$(realpath "$0")")
 
-echo "Pulling latest images..."
-$DOCKER_COMPOSE_CMD pull
+echo "Running update script..."
+UPDATE_SCRIPT="$scrDir/../docker/update.sh"
 
-echo "Stopping and removing existing containers..."
-$DOCKER_COMPOSE_CMD down
-
-echo "Starting new containers..."
-$DOCKER_COMPOSE_CMD up -d
-
-echo "Removing old images..."
-docker image prune -f
-
-echo "Deployment completed successfully."
+$UPDATE_SCRIPT

--- a/.github/workflows/autopromote.yml
+++ b/.github/workflows/autopromote.yml
@@ -19,7 +19,7 @@ jobs:
         uses: mtanzi/action-automerge@v1
         id: merge
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PRIVATE_TOKEN }}
           source: "main"
           target: "release"
 
@@ -34,6 +34,6 @@ jobs:
   #       uses: mtanzi/action-automerge@v1
   #       id: merge
   #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         github_token: ${{ secrets.PRIVATE_TOKEN }}
   #         source: "development"
   #         target: "beta"

--- a/.github/workflows/autopromote.yml
+++ b/.github/workflows/autopromote.yml
@@ -1,5 +1,5 @@
-# Credit: Workflow configs copied Wynntils
-#
+# Credit: Workflow configs inspired from Wynntils
+
 name: Autopromote branches
 
 on:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,8 +1,4 @@
-# Credit: Workflow configs inspired by Wynntils and moto-bot
-#
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
+# Credit: Workflow configs inspired from Wynntils and moto-bot
 name: Python Format & Test
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           path: version.json
 
   build-fazcord:
-    name: Build fazord Docker Images
+    name: Build fazcord Docker Images
     needs: [changelog] # Build needs the new version number
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
   push:
     branches:
       - release
-  workflow_run:
-    workflows: ["Autopromote branches"]
-    types:
-      - completed
 
 jobs:
   changelog:
@@ -40,7 +36,7 @@ jobs:
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5.2.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PRIVATE_TOKEN }}
           git-user-name: "faz-bot-bot"
           git-user-email: "fazuhhh@proton.me"
           version-file: ./version.json
@@ -75,7 +71,7 @@ jobs:
         with:
           registry: ghcr.io
           username: FAZuH
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PRIVATE_TOKEN }}
 
       - name: Set up build date
         run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
@@ -120,7 +116,7 @@ jobs:
         with:
           registry: ghcr.io
           username: FAZuH
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PRIVATE_TOKEN }}
 
       - name: Set up build date
         run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,4 +191,4 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
 
       - name: Deploy
-        run: ssh -o LogLevel=QUIET -t ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "/srv/faz-bot/docker/deploy.sh"
+        run: ssh -o LogLevel=QUIET -t ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "/srv/faz-bot/.github/deploy.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Credit: Workflow configs inspired by Wynntils and moto-bot
+# Credit: Workflow configs inspired from Wynntils and moto-bot
 
 name: Release & Deploy
 

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+scrDir=$(dirname "$(realpath "$0")")
+
+COMPOSE_FILE="$scrDir/docker-compose.yml"
+COMPOSE_CMD="docker-compose -f $COMPOSE_FILE"
+
+echo "Pulling latest images..."
+$COMPOSE_CMD pull
+
+echo "Stopping and removing existing containers..."
+$COMPOSE_CMD down
+
+echo "Starting new containers..."
+$COMPOSE_CMD up -d
+
+echo "Removing old images..."
+docker image prune -f
+
+echo "Update completed successfully."


### PR DESCRIPTION
Fix release workflow not being triggered by pushes made by autopromote workflow. This happened because autopromote used GITHUB_TOKEN to push the changes, which would not trigger other workflows.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow