### PR TITLE
fix(api): Fix WynnApi occasionally throwing KeyError

### DIFF
--- a/fazutil/api/wynn/model/headers.py
+++ b/fazutil/api/wynn/model/headers.py
@@ -11,9 +11,14 @@ class Headers:
         self._cache_control = raw["Cache-Control"]
         self._date = HeaderDateField(raw["Date"])
         self._expires = HeaderDateField(raw["Expires"])
-        self._ratelimit_limit = int(raw["ratelimit-limit"])
-        self._ratelimit_remaining = int(raw["ratelimit-remaining"])
-        self._ratelimit_reset = int(raw["ratelimit-reset"])
+        try:
+            self._ratelimit_limit = int(raw["ratelimit-limit"])
+            self._ratelimit_remaining = int(raw["ratelimit-remaining"])
+            self._ratelimit_reset = int(raw["ratelimit-reset"])
+        except KeyError:
+            self._ratelimit_limit = int(raw["Ratelimit-Limit"])
+            self._ratelimit_remaining = int(raw["Ratelimit-Remaining"])
+            self._ratelimit_reset = int(raw["Ratelimit-Reset"])
 
     def to_datetime(self) -> datetime:
         """


### PR DESCRIPTION
Sometimes the ratelimit headers start are all lowercase, sometimes not. The error stops happening on 4594133152e96a23951dd534c4189018aac36224