### PR TITLE
ci: fix deploy.sh failing to git pull [skip ci]

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-echo "Pulling latest git commit..."
-git pull origin main
-
 scrDir=$(dirname "$(realpath "$0")")
+
+cd "$scrDir" || exit
+
+echo "Pulling latest git commit in $scrDir..."
+git pull origin main
 
 echo "Running update script..."
 UPDATE_SCRIPT="$scrDir/../docker/update.sh"


### PR DESCRIPTION
Fix deploy.sh script failing to git pull when working directory is not set to the project root directory.