### PR TITLE
chore(ci): fix release workflow fail on empty changelog [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           version-file: ./version.json
           skip-version-file: true
           skip-git-pull: true
+          skip-on-empty: false
           pre-release: false
           release-count: 5
 
@@ -96,8 +97,8 @@ jobs:
             commit=${{ github.sha }}
             build_date=${{ env.date }}
 
-  build-api_collect:
-    name: Build api_collect Docker Images
+  build-fazdb:
+    name: Build fazdb Docker Images
     needs: [changelog] # Build needs the new version number
     runs-on: ubuntu-latest
     steps:
@@ -126,7 +127,7 @@ jobs:
         with:
           name: version
 
-      - name: Build and Push api_collect
+      - name: Build and Push fazdb
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -134,8 +135,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/fazuh/api_collect:latest
-            ghcr.io/fazuh/api_collect:${{ needs.changelog.outputs.tag }}
+            ghcr.io/fazuh/fazdb:latest
+            ghcr.io/fazuh/fazdb:${{ needs.changelog.outputs.tag }}
           labels: |
             version=${{ needs.changelog.outputs.tag }}
             commit=${{ github.sha }}
@@ -143,7 +144,7 @@ jobs:
 
   release-github:
     name: Release to GitHub
-    needs: [build-fazcord, build-api_collect, changelog]
+    needs: [build-fazcord, build-fazdb, changelog]
     if: ${{ needs.changelog.outputs.skipped != 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -180,7 +181,7 @@ jobs:
 
   deploy:
     name: Deploy to Server
-    needs: [build-fazcord, build-api_collect, changelog]
+    needs: [build-fazcord, build-fazdb, changelog]
     runs-on: ubuntu-latest
     if: ${{ needs.changelog.outputs.skipped != 'true' }}
     steps:


### PR DESCRIPTION
Fix release workflow failing to run on empty changelog when skip-on-empty is set to true (default value). This should fix [this workflow
error](https://github.com/FAZuH/faz-bot/actions/runs/10753439637/job/29822886554)