### PR TITLE
ci: fix deploy running git pull on wrong dir [skip ci]

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-scrDir=$(dirname "$(realpath "$0")")
+projectDir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$scrDir" || exit
+cd "$projectDir" || exit
 
-echo "Pulling latest git commit in $scrDir..."
+echo "Pulling latest git commit in $projectDir..."
 git pull origin main
 
 echo "Running update script..."
-UPDATE_SCRIPT="$scrDir/../docker/update.sh"
+UPDATE_SCRIPT="$projectDir/docker/update.sh"
 
 $UPDATE_SCRIPT


### PR DESCRIPTION
Modify cd to go to project directory instead of .github so git can pull properly.