### PR TITLE
ci: change lint and formatter to Ruff

### DIFF
--- a/.github/workflows/autopromote.yml
+++ b/.github/workflows/autopromote.yml
@@ -13,9 +13,10 @@ jobs:
     name: Merge main into release after a PR is merged
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: merge
+
+      - name: Merge
         uses: mtanzi/action-automerge@v1
         id: merge
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,12 +14,13 @@ jobs:
     if: "! github.event.pull_request.draft"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Stop default MySQL server (if any)
+      - name: Stop Default MySQL Server (if any)
         run: sudo service mysql stop
 
-      - name: Setup MariaDB
+      - name: Set Up MariaDB
         run: |
           docker run \
           -e MYSQL_ROOT_PASSWORD=password \
@@ -30,21 +31,22 @@ jobs:
           -v ${GITHUB_WORKSPACE}/mysql/init:/docker-entrypoint-initdb.d \
           -d -p "3306:3306" mariadb:11.4.2
 
-      - name: Set up Python 3.12
+      - name: Set Up Python 3.12
         uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: "3.12.4"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest black
+          pip install pytest ruff
           pip install -r requirements-dev.txt
 
-      - name: Format with Black
-        run: black .
+      - name: Lint & Format with Ruff
+        run: python -m ruff check --fix
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Commit Lint & Format
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_user_name: "faz-bot-bot"
           commit_user_email: "fazuhhh@proton.me"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,25 @@ jobs:
       clean_changelog: ${{ steps.changelog.outputs.clean_changelog }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Set Up Node
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
-      - run: |
+      - name: Install Changelog Tools
+        run: |
           npm install conventional-changelog-conventionalcommits@7.0.2
           npm install conventional-recommended-bump@9.0.0
 
       - name: Set Up version.json
         run: echo "{"version":$(git describe --tags --abbrev=0)}" > version.json
 
-      - name: Create changelog
+      - name: Create Changelog
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5.2.1
         with:
@@ -57,27 +60,28 @@ jobs:
     needs: [changelog] # Build needs the new version number
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up QEMU
+      - name: Set Up QEMU
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
 
-      - name: Set up Docker Buildx
+      - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log In to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: FAZuH
           password: ${{ secrets.PRIVATE_TOKEN }}
 
-      - name: Set up build date
+      - name: Set Up Build Date
         run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
-      - name: Download version information
+      - name: Download Version Information
         uses: actions/download-artifact@v4 # Download version information from changelog
         with:
           name: version
@@ -102,27 +106,28 @@ jobs:
     needs: [changelog] # Build needs the new version number
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up QEMU
+      - name: Set Up QEMU
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
 
-      - name: Set up Docker Buildx
+      - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log In to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: FAZuH
           password: ${{ secrets.PRIVATE_TOKEN }}
 
-      - name: Set up build date
+      - name: Set Up Build Date
         run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
-      - name: Download version information
+      - name: Download Version Information
         uses: actions/download-artifact@v4 # Download version information from changelog
         with:
           name: version

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_COMPOSE := $(DOCKER_DIR)/docker-compose.yml
 SCRIPT := ./makefile.sh
 .DEFAULT_GOAL := help
 
-.PHONY: wait-for-mysql build-all up-all down-all api-collect bot mysql pma test lint format rmpycache countlines
+.PHONY: wait-for-mysql build-all up-all down-all api-collect bot mysql pma test lint-format rmpycache countlines
 
 help:
 	@echo "Usage:"
@@ -15,8 +15,7 @@ help:
 	@echo "  make sql act=[build|up|down|bash]          # Manage sql service"
 	@echo "  make pma act=[build|up|down|bash]          # Manage phpmyadmin service"
 	@echo "  make test                                  # Run python tests"
-	@echo "  make lint                                  # Run python linting"
-	@echo "  make format                                # Run python formatting with isort and black"
+	@echo "  make lint-format                           # Run python formatting with Ruff"
 	@echo "  make rmpycache                             # Remove __pycache__ directories"
 	@echo "  make countlines                            # Count sum of lines of all python files"
 
@@ -60,11 +59,8 @@ pma:
 test:
 	python -m pytest --disable-warnings tests
 
-lint:
-	python -m pylint $$(git ls-files '*.py') --disable=R0801,R0901,R0913,R0916,R0912,R0902,R0914,R01702,R0917,R0904,R0911,R0915,R0903,C0301,C0114,C0115,C0116,C3001,W
-
-format:
-	python -m isort . && python -m black .
+lint-format:
+	python -m ruff check --fix
 
 
 rmpycache:
@@ -76,6 +72,5 @@ countlines:
 
 clean:
 	make rmpycache
-	make format
+	make lint-format
 	make test
-	make lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,78 @@
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py312"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E731"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
Change Python linter and formatter to Ruff. It's fast and has "Drop-in parity with Flake8, isort, and Black"