### PR TITLE
ci: fix format action failure

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Format with Ruff
-        run: python -m ruff check --fix
+        run: python -m ruff check --fix --exit-zero
 
       - name: Commit Format
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Fix pull-request workflow failing due to Ruff lint & formatter returning non-zero exit code upon detecting lint violations