### PR TITLE
fix: Fix error on specific CraftedUtil arguments

### DIFF
--- a/fazcord/wynn/crafted_util.py
+++ b/fazcord/wynn/crafted_util.py
@@ -50,14 +50,15 @@ class CraftedUtil:
             ing_base_values = np.linspace(ing.min_value, ing.max_value, 101)
             ing_rolls_boosted = np.floor(
                 np.round(ing_base_values) * ing_stat_eff
-            ).astype(int) - np.floor(ing.min_value * ing_stat_eff).astype(int)
-            ingredient_rolls_occurrences = np.bincount(ing_rolls_boosted)
-            ingredient_prob_dist = ingredient_rolls_occurrences / 101
+            ).astype(int)
+            offset = -np.min(ing_rolls_boosted)  # Offset to ensure no negative indices
+            ing_rolls_occurrences = np.bincount(ing_rolls_boosted + offset)
+            ing_prob_dist = ing_rolls_occurrences / 101
 
             # Assign values into class attributes
-            self._ing_prob_dists.append(ingredient_prob_dist)
-            self._crafted_roll_min += np.floor(ing.min_value * ing_stat_eff)
-            self._crafted_roll_max += np.floor(ing.max_value * ing_stat_eff)
+            self._ing_prob_dists.append(ing_prob_dist)
+            self._crafted_roll_min += np.min(ing_rolls_boosted)
+            self._crafted_roll_max += np.max(ing_rolls_boosted)
 
     def _calculate_crafted_probabilities(self):
         # Calculate crafted roll probabilities

--- a/tests/fazcord/util/test_crafted_util.py
+++ b/tests/fazcord/util/test_crafted_util.py
@@ -6,15 +6,21 @@ from fazcord.wynn.ingredient_field import IngredientField
 
 
 class TestCraftedUtil(TestCase):
-    def test_crafted_util(self) -> None:
-        # PREPARE
+    # 1. All positive
+    # 2. Negative boost
+    # 3. Negative min_value
+    # 4. Negative max_value
+    # 5. All negative
+
+    def test_12lq(self) -> None:
+        # Prepare
         ing1 = IngredientField(1, 2, 50)
         ing2 = IngredientField(1, 2, 50)
         ing3 = IngredientField(1, 2, 50)
         ing4 = IngredientField(1, 2, 50)
         craftedutil = CraftedUtil([ing1, ing2, ing3, ing4])
 
-        # ASSERT
+        # Assert
         self.assertEqual(4, craftedutil.crafted_roll_min)
         self.assertEqual(12, craftedutil.crafted_roll_max)
         self.assertEqual([ing1, ing2, ing3, ing4], craftedutil.ingredients)
@@ -23,3 +29,68 @@ class TestCraftedUtil(TestCase):
         self.assertAlmostEqual(Decimal(0.375), craftedutil.craft_probs[8], delta=0.001)
         self.assertAlmostEqual(Decimal(0.255), craftedutil.craft_probs[10], delta=0.001)
         self.assertAlmostEqual(Decimal(0.065), craftedutil.craft_probs[12], delta=0.001)
+
+    def test_negative_boost(self) -> None:
+        # Prepare
+        ing1 = IngredientField(0, 10, -500)
+        craftedutil = CraftedUtil([ing1])
+
+        # Assert
+        self.assertEqual(-40, float(craftedutil.crafted_roll_min))
+        self.assertEqual(0, float(craftedutil.crafted_roll_max))
+
+    def test_negative_min_value(self) -> None:
+        # Prepare
+        ing1 = IngredientField(-10, 0, 50)
+        craftedutil = CraftedUtil([ing1])
+
+        # Assert
+        self.assertEqual(-15, float(craftedutil.crafted_roll_min))
+        self.assertEqual(0, float(craftedutil.crafted_roll_max))
+
+    def test_negative_max_value(self) -> None:
+        # Prepare
+        ing1 = IngredientField(-20, -10, 50)
+        craftedutil = CraftedUtil([ing1])
+
+        # Assert
+        self.assertEqual(-30, float(craftedutil.crafted_roll_min))
+        self.assertEqual(-15, float(craftedutil.crafted_roll_max))
+
+    def test_all_negative(self) -> None:
+        # Prepare
+        ing1 = IngredientField(-20, -10, -500)
+        craftedutil = CraftedUtil([ing1])
+
+        # Assert
+        self.assertEqual(40, float(craftedutil.crafted_roll_min))
+        self.assertEqual(80, float(craftedutil.crafted_roll_max))
+
+    def test_distributions(self) -> None:
+        # Prepare
+        ing1 = IngredientField(0, 1)
+        ing2 = IngredientField(0, 2)
+        ing3 = IngredientField(0, 3)
+        ing4 = IngredientField(0, 4)
+        ing5 = IngredientField(0, 5)
+        craft1 = CraftedUtil([ing1])
+        craft2 = CraftedUtil([ing2])
+        craft3 = CraftedUtil([ing3])
+        craft4 = CraftedUtil([ing4])
+        craft5 = CraftedUtil([ing5])
+
+        # Assert
+        def check(craft: CraftedUtil, expected: list[float]) -> None:
+            for i in range(len(expected)):
+                self.assertAlmostEqual(
+                    expected[i], float(craft.craft_probs[i]), delta=0.001
+                )
+
+        check(craft1, [0.5049505, 0.4950495])
+        check(craft2, [0.25742574, 0.48514851, 0.25742574])
+        check(craft3, [0.16831683, 0.32673267, 0.33663366, 0.16831683])
+        check(craft4, [0.12871287, 0.24752475, 0.24752475, 0.24752475, 0.12871287])
+        check(
+            craft5,
+            [0.10891089, 0.18811881, 0.20792079, 0.18811881, 0.20792079, 0.0990099],
+        )


### PR DESCRIPTION
Fix unexpected error when CraftedUtil is called with large enough negative boost value. This error occurs due to flawed code failing to offset ing_rolls_boosted to prevent negative element error on numpy.bincount().

Also added tests for CraftedUtil