### PR TITLE
fix: Fix deploy workflow

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,11 +14,13 @@ set -e
 
 
 main() {
-    # 1. Make sure database is running
+    # 1. Make sure database is running before updating it. Needed for step 2
     $COMPOSE up mysql -d
     "docker/wait-for-it.sh" -t 5 mysql:3306 -- echo "MySQL is ready!"
 
-    # 2. Pull git changes and update database
+    # 2. Pull git changes and update database.
+    # This is to ensure scripts and docker configs are 
+    # in the latest version before running docker-compose pull
     $UPDATE_SCRIPT
 
     echo "Pulling latest images..."
@@ -26,11 +28,13 @@ main() {
     $COMPOSE pull 
 
     echo "Starting new containers..."
-    # 4. Start fazcollect and fazcord service
-    $COMPOSE up fazcollect fazcord -d
+    # 4. Start services
+    # Note that docker will only recreate containers 
+    # if the image (or docker-compose config) has changed
+    $COMPOSE up mysql fazcollect fazcord -d
 
     echo "Removing old images..."
-    # 5. Remove old images
+    # 5. Remove old images (if any)
     docker image prune -f
 
     echo "Update completed successfully."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,20 +14,22 @@ set -e
 
 
 main() {
+    # 1. Make sure database is running
     $COMPOSE up mysql -d
 
+    # 2. Pull git changes and update database
     $UPDATE_SCRIPT
 
     echo "Pulling latest images..."
+    # 3. Pull latest docker images
     $COMPOSE pull 
 
-    echo "Stopping and removing existing containers..."
-    $COMPOSE down
-
     echo "Starting new containers..."
-    $COMPOSE up -d
+    # 4. Start fazcollect and fazcord service
+    $COMPOSE up fazcollect fazcord -d
 
     echo "Removing old images..."
+    # 5. Remove old images
     docker image prune -f
 
     echo "Update completed successfully."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,6 +16,7 @@ set -e
 main() {
     # 1. Make sure database is running
     $COMPOSE up mysql -d
+    "docker/wait-for-it.sh" -t 5 mysql:3306 -- echo "MySQL is ready!"
 
     # 2. Pull git changes and update database
     $UPDATE_SCRIPT

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -13,7 +13,7 @@ VENV_ACTIVATE_PATH="$PROJECT_PATH/.venv/bin/activate"
 main() {
     cd "$PROJECT_PATH" || exit
 
-    git pull origin main
+    git pull
 
     if [ ! -f "$VENV_ACTIVATE_PATH" ]; then
         echo "Virtual environment not found. Exiting..."


### PR DESCRIPTION
- On prod server, `git fetch`, `git checkout origin/fix/fix-deploy-workflow`.
- On local, run `ssh ... cd /srv/faz-bot && git pull && /srv/faz-bot/scripts/deploy.sh`
- Debug, and repeat

## Issues
### (SOLVED) `docker-compose` doesn't recognize services if the services are started locally.
Note that in both cases, the new images are successfully pulled and started.
**Case 1**
i. `make reset-docker` (on server, on project root)
ii. `./scripts/deploy.sh` (on server, on project root)
`docker-compose down` on server successfully stops the services here
**Case 2**
i. `make reset-docker` (on server, on project root)
ii. `ssh server-faz-bot "cd /srv/faz-bot && git pull && /srv/faz-bot/scripts/deploy.sh` (on local)
`docker-compose down` on server fails to stops the services here
**Solution (ffs)**
Case 2 happens if `docker-compose down` is executed, after changing directory into project root using a symlink. This does not happen when `docker-compose down` is executed after changing directory into `/srv/faz-bot`.
![image](https://github.com/user-attachments/assets/8451e17c-36a2-4c45-9763-4bc7fb3489ec)

## Test
- [x] Test deploy script after `make reset-docker`
- [x] Test deploy script while all services are not running
- [x] Test deploy script while all services are running
- [ ] Test deploy script while all services are running after new release
